### PR TITLE
Linux 5 15 support

### DIFF
--- a/sync
+++ b/sync
@@ -85,28 +85,28 @@ def hack_content(fname, data):
         if fname == 'kvm_main.c' and inside_block(r'^int kvm_init\(', r'^}'):
             if match(r'return 0;'):
                 w('\tprintk("loaded kvm module (%s)\\n");\n' % (version,))
-	if match(r'^#define TRACE_INCLUDE_PATH'):
-	    line = '#define TRACE_INCLUDE_PATH x86'
-	if match(r'ms_hyperv\.nested_features & HV_X64_NESTED_GUEST_MAPPING_FLUSH$'):
-	    w(line)
-	    line = '\t    && LINUX_VERSION_CODE >= KERNEL_VERSION(4,21,0)'
-	if match(r'^static void kvm_handle_intel_pt_intr'):
+    if match(r'^#define TRACE_INCLUDE_PATH'):
+        line = '#define TRACE_INCLUDE_PATH x86'
+    if match(r'ms_hyperv\.nested_features & HV_X64_NESTED_GUEST_MAPPING_FLUSH$'):
+        w(line)
+        line = '\t    && LINUX_VERSION_CODE >= KERNEL_VERSION(4,21,0)'
+    if match(r'^static void kvm_handle_intel_pt_intr'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)')
-	if match_block_end(r'^static void kvm_handle_intel_pt_intr', '^}'):
-	    w(line)
-	    line = '#endif'
-	if match(r'handle_intel_pt_intr\s*='):
+    if match_block_end(r'^static void kvm_handle_intel_pt_intr', '^}'):
+        w(line)
+        line = '#endif'
+    if match(r'handle_intel_pt_intr\s*='):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)')
-	    w(line)
-	    line = '#endif'
-	if match(r'boot_cpu_data.x86_cache_bits'):
+        w(line)
+        line = '#endif'
+    if match(r'boot_cpu_data.x86_cache_bits'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,0)')
-	    w(line)
-	    w('#else')
-	    w(sub('x86_cache_bits', 'x86_phys_bits', line))
-	    line = '#endif'
-	if match_block_end(r'^static void kvm_mmu_notifier_invalidate_range_end', '^}'):
-	    w(line)
+        w(line)
+        w('#else')
+        w(sub('x86_cache_bits', 'x86_phys_bits', line))
+        line = '#endif'
+    if match_block_end(r'^static void kvm_mmu_notifier_invalidate_range_end', '^}'):
+        w(line)
             w('')
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)')
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0)')
@@ -142,38 +142,38 @@ def hack_content(fname, data):
             w('#define kvm_mmu_notifier_invalidate_range_end __kvm_mmu_notifier_invalidate_range_end')
             w('#endif')
             line = ''
-	if match(r'freq->policy->cpus'):
+    if match(r'freq->policy->cpus'):
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0)')
-	    w('        cpu = freq->cpu;');
-	    w('#else')
-	    w(line)
-	    line = '#endif'
-	if match(r'DEFINE_STATIC_KEY_FALSE.vmx_l1d_should_flush'):
+        w('        cpu = freq->cpu;');
+        w('#else')
+        w(line)
+        line = '#endif'
+    if match(r'DEFINE_STATIC_KEY_FALSE.vmx_l1d_should_flush'):
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0)')
             w('static DEFINE_STATIC_KEY_FALSE(mds_user_clear);')
-	    w('#endif')
-	if match(r'BUILD_BUG_ON_MSG.*INTEL_PMC_MAX_FIXED'):
+        w('#endif')
+    if match(r'BUILD_BUG_ON_MSG.*INTEL_PMC_MAX_FIXED'):
             line = sub(r'!=', '>', line)
-	if match(r'BUILD_BUG_ON.*(CPUID_LNX_4|CPUID_7_1_EAX)') or \
-			(inside_block(r'^static .*reverse_cpuid', r'^}') and match('CPUID_7_1_EAX')):
+    if match(r'BUILD_BUG_ON.*(CPUID_LNX_4|CPUID_7_1_EAX)') or \
+            (inside_block(r'^static .*reverse_cpuid', r'^}') and match('CPUID_7_1_EAX')):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)')
-	    w(line)
+        w(line)
             line = '#endif'
-	if match(r'AVX512_BF16'):
+    if match(r'AVX512_BF16'):
             # For Linux versions that lack CPUID_7_1_EAX
             line = sub(r'F\(AVX512_BF16\)', '(1u << 5)', line)
-	if match(r'^SYM_FUNC_START'):
+    if match(r'^SYM_FUNC_START'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)')
-	    w(line)
-	    w('#else')
+        w(line)
+        w('#else')
             w(sub(r'^SYM_FUNC_START', 'ENTRY', line))
-	    line = '#endif'
-	if match(r'^SYM_FUNC_END'):
+        line = '#endif'
+    if match(r'^SYM_FUNC_END'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)')
-	    w(line)
-	    w('#else')
+        w(line)
+        w('#else')
             w(sub(r'^SYM_FUNC_END', 'ENDPROC', line))
-	    line = '#endif'
+        line = '#endif'
 
         for ident in compat_apis:
             line = sub(r'\b' + ident + r'\b', 'kvm_' + ident, line)
@@ -197,10 +197,10 @@ hack_files = {
     'x86': str.split('kvm_main.c mmu/mmu.c x86.c x86.h irq.c irq.h lapic.c'
                      ' lapic.h i8254.c i8259.c eventfd.c emulate.c async_pf.c cpuid.h'
                      ' cpuid.c pmu.c pmu_amd.c mmu/paging_tmpl.h mtrr.c mmu/page_track.c'
-		     ' vmx/capabilities.h pmu_amd.c svm.c tss.h trace.h'
-		     ' vmx/evmcs.c vmx/evmcs.h vmx/nested.c vmx/nested.h'
-		     ' vmx/pmu_intel.c vmx/vmcs12.c vmx/vmcs12.h vmx/vmcs.h'
-		     ' vmx/vmcs_shadow_fields.h vmx/vmenter.S vmx/vmx.c vmx/vmx.h'),
+             ' vmx/capabilities.h pmu_amd.c svm.c tss.h trace.h'
+             ' vmx/evmcs.c vmx/evmcs.h vmx/nested.c vmx/nested.h'
+             ' vmx/pmu_intel.c vmx/vmcs12.c vmx/vmcs12.h vmx/vmcs.h'
+             ' vmx/vmcs_shadow_fields.h vmx/vmenter.S vmx/vmx.c vmx/vmx.h'),
 }
 
 def mkdir(dir):
@@ -282,7 +282,7 @@ def header_sync(arch):
     generic_headers = (
         [x
          for dir in ['%(linux)s/include/asm-generic/mshyperv.h',
-		     '%(linux)s/include/clocksource/hyperv_timer.h']
+             '%(linux)s/include/clocksource/hyperv_timer.h']
          for x in glob(dir % { 'arch': arch, 'linux': linux })
          ])
     for file in generic_headers:
@@ -302,11 +302,11 @@ def source_sync(arch):
     T = 'source'
     rmtree(T)
     sourcedirs = { '%(linux)s/arch/%(arch)s/kvm': 'source',
-		    '%(linux)s/arch/%(arch)s/kvm/mmu': 'source/mmu',
-		    '%(linux)s/arch/%(arch)s/kvm/vmx': 'source/vmx',
-		    '%(linux)s/virt/kvm': 'source'}
+            '%(linux)s/arch/%(arch)s/kvm/mmu': 'source/mmu',
+            '%(linux)s/arch/%(arch)s/kvm/vmx': 'source/vmx',
+            '%(linux)s/virt/kvm': 'source'}
     for srcdir, outdir in sourcedirs.items():
-	pattern = (srcdir + '/*.[chS]') % { 'linux': linux, 'arch': arch }
+    pattern = (srcdir + '/*.[chS]') % { 'linux': linux, 'arch': arch }
         sources = [file
                for file in glob(pattern)
                if not file.endswith('.mod.c')]

--- a/sync
+++ b/sync
@@ -194,13 +194,15 @@ def unifdef(fname):
     file(fname, 'w').write(data)
 
 hack_files = {
-    'x86': str.split('kvm_main.c mmu/mmu.c x86.c x86.h irq.c irq.h lapic.c'
-                     ' lapic.h i8254.c i8259.c eventfd.c emulate.c async_pf.c cpuid.h'
-                     ' cpuid.c pmu.c pmu_amd.c mmu/paging_tmpl.h mtrr.c mmu/page_track.c'
-             ' vmx/capabilities.h pmu_amd.c svm.c tss.h trace.h'
-             ' vmx/evmcs.c vmx/evmcs.h vmx/nested.c vmx/nested.h'
-             ' vmx/pmu_intel.c vmx/vmcs12.c vmx/vmcs12.h vmx/vmcs.h'
-             ' vmx/vmcs_shadow_fields.h vmx/vmenter.S vmx/vmx.c vmx/vmx.h'),
+    'x86': str.split('async_pf.c cpuid.c cpuid.h emulate.c eventfd.c i8254.c i8259.c irq.c irq.h'
+                     ' kvm_main.c lapic.c lapic.h'
+                     ' mmu/mmu_audit.c mmu/mmu.c mmu/page_track.c mmu/paging_tmpl.h mtrr.c'
+                     ' pmu.c'
+                     ' svm/avic.c svm/nested.c svm/pmu.c svm/svm_onhyperv.c svm/svm.c svm/vmenter.S'
+                     ' trace.h tss.h'
+                     ' vmx/capabilities.h vmx/evmcs.c vmx/evmcs.h vmx/nested.c vmx/nested.h vmx/pmu_intel.c '
+                     ' vmx/vmcs_shadow_fields.h vmx/vmcs.h vmx/vmcs12.c vmx/vmcs12.h vmx/vmenter.S vmx/vmx.c vmx/vmx.h'
+                     ' x86.c x86.h'),
 }
 
 def mkdir(dir):
@@ -294,7 +296,9 @@ def header_sync(arch):
     hack_file(T, 'include/linux/kvm_host.h')
     hack_file(T, 'include/asm-%(arch)s/kvm_host.h' % { 'arch': arch })
     if arch == 'x86':
-        hack_file(T, 'include/asm-x86/kvm_emulate.h')
+        # the file structure changed with newer kernels
+        if os.path.exists(T + "/" + 'include/asm-x86/kvm_emulate.h'):
+            hack_file(T, 'include/asm-x86/kvm_emulate.h')
     copy_if_changed(T, '.')
     rmtree(T)
 
@@ -304,6 +308,7 @@ def source_sync(arch):
     sourcedirs = { '%(linux)s/arch/%(arch)s/kvm': 'source',
             '%(linux)s/arch/%(arch)s/kvm/mmu': 'source/mmu',
             '%(linux)s/arch/%(arch)s/kvm/vmx': 'source/vmx',
+            '%(linux)s/arch/%(arch)s/kvm/svm': 'source/svm',
             '%(linux)s/virt/kvm': 'source'}
     for srcdir, outdir in sourcedirs.items():
         pattern = (srcdir + '/*.[chS]') % { 'linux': linux, 'arch': arch }
@@ -317,6 +322,11 @@ def source_sync(arch):
 
             if out[-1] == 'c':
                 unifdef(out)
+
+    if arch == 'x86':
+        # the file structure changed with newer kernels
+        if os.path.exists(T + "/" + 'kvm/kvm_emulate.h'):
+            hack_file(T, 'kvm/kvm_emulate.h')
 
     for i in hack_files[arch]:
         hack_file(T, i)

--- a/sync
+++ b/sync
@@ -85,28 +85,28 @@ def hack_content(fname, data):
         if fname == 'kvm_main.c' and inside_block(r'^int kvm_init\(', r'^}'):
             if match(r'return 0;'):
                 w('\tprintk("loaded kvm module (%s)\\n");\n' % (version,))
-    if match(r'^#define TRACE_INCLUDE_PATH'):
-        line = '#define TRACE_INCLUDE_PATH x86'
-    if match(r'ms_hyperv\.nested_features & HV_X64_NESTED_GUEST_MAPPING_FLUSH$'):
-        w(line)
-        line = '\t    && LINUX_VERSION_CODE >= KERNEL_VERSION(4,21,0)'
-    if match(r'^static void kvm_handle_intel_pt_intr'):
+        if match(r'^#define TRACE_INCLUDE_PATH'):
+            line = '#define TRACE_INCLUDE_PATH x86'
+        if match(r'ms_hyperv\.nested_features & HV_X64_NESTED_GUEST_MAPPING_FLUSH$'):
+            w(line)
+            line = '\t    && LINUX_VERSION_CODE >= KERNEL_VERSION(4,21,0)'
+        if match(r'^static void kvm_handle_intel_pt_intr'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)')
-    if match_block_end(r'^static void kvm_handle_intel_pt_intr', '^}'):
-        w(line)
-        line = '#endif'
-    if match(r'handle_intel_pt_intr\s*='):
+        if match_block_end(r'^static void kvm_handle_intel_pt_intr', '^}'):
+            w(line)
+            line = '#endif'
+        if match(r'handle_intel_pt_intr\s*='):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)')
-        w(line)
-        line = '#endif'
-    if match(r'boot_cpu_data.x86_cache_bits'):
+            w(line)
+            line = '#endif'
+        if match(r'boot_cpu_data.x86_cache_bits'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,19,0)')
-        w(line)
-        w('#else')
-        w(sub('x86_cache_bits', 'x86_phys_bits', line))
-        line = '#endif'
-    if match_block_end(r'^static void kvm_mmu_notifier_invalidate_range_end', '^}'):
-        w(line)
+            w(line)
+            w('#else')
+            w(sub('x86_cache_bits', 'x86_phys_bits', line))
+            line = '#endif'
+        if match_block_end(r'^static void kvm_mmu_notifier_invalidate_range_end', '^}'):
+            w(line)
             w('')
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,0,0)')
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(4,19,0)')
@@ -142,38 +142,38 @@ def hack_content(fname, data):
             w('#define kvm_mmu_notifier_invalidate_range_end __kvm_mmu_notifier_invalidate_range_end')
             w('#endif')
             line = ''
-    if match(r'freq->policy->cpus'):
+        if match(r'freq->policy->cpus'):
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0)')
-        w('        cpu = freq->cpu;');
-        w('#else')
-        w(line)
-        line = '#endif'
-    if match(r'DEFINE_STATIC_KEY_FALSE.vmx_l1d_should_flush'):
+            w('        cpu = freq->cpu;');
+            w('#else')
+            w(line)
+            line = '#endif'
+        if match(r'DEFINE_STATIC_KEY_FALSE.vmx_l1d_should_flush'):
             w('#if LINUX_VERSION_CODE < KERNEL_VERSION(5,2,0)')
             w('static DEFINE_STATIC_KEY_FALSE(mds_user_clear);')
-        w('#endif')
-    if match(r'BUILD_BUG_ON_MSG.*INTEL_PMC_MAX_FIXED'):
+            w('#endif')
+        if match(r'BUILD_BUG_ON_MSG.*INTEL_PMC_MAX_FIXED'):
             line = sub(r'!=', '>', line)
-    if match(r'BUILD_BUG_ON.*(CPUID_LNX_4|CPUID_7_1_EAX)') or \
-            (inside_block(r'^static .*reverse_cpuid', r'^}') and match('CPUID_7_1_EAX')):
+        if match(r'BUILD_BUG_ON.*(CPUID_LNX_4|CPUID_7_1_EAX)') or \
+           (inside_block(r'^static .*reverse_cpuid', r'^}') and match('CPUID_7_1_EAX')):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)')
-        w(line)
+            w(line)
             line = '#endif'
-    if match(r'AVX512_BF16'):
+        if match(r'AVX512_BF16'):
             # For Linux versions that lack CPUID_7_1_EAX
             line = sub(r'F\(AVX512_BF16\)', '(1u << 5)', line)
-    if match(r'^SYM_FUNC_START'):
+        if match(r'^SYM_FUNC_START'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)')
-        w(line)
-        w('#else')
+            w(line)
+            w('#else')
             w(sub(r'^SYM_FUNC_START', 'ENTRY', line))
-        line = '#endif'
-    if match(r'^SYM_FUNC_END'):
+            line = '#endif'
+        if match(r'^SYM_FUNC_END'):
             w('#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,5,0)')
-        w(line)
-        w('#else')
+            w(line)
+            w('#else')
             w(sub(r'^SYM_FUNC_END', 'ENDPROC', line))
-        line = '#endif'
+            line = '#endif'
 
         for ident in compat_apis:
             line = sub(r'\b' + ident + r'\b', 'kvm_' + ident, line)
@@ -306,7 +306,7 @@ def source_sync(arch):
             '%(linux)s/arch/%(arch)s/kvm/vmx': 'source/vmx',
             '%(linux)s/virt/kvm': 'source'}
     for srcdir, outdir in sourcedirs.items():
-    pattern = (srcdir + '/*.[chS]') % { 'linux': linux, 'arch': arch }
+        pattern = (srcdir + '/*.[chS]') % { 'linux': linux, 'arch': arch }
         sources = [file
                for file in glob(pattern)
                if not file.endswith('.mod.c')]

--- a/x86/Kbuild
+++ b/x86/Kbuild
@@ -1,13 +1,14 @@
 obj-m := kvm.o kvm-intel.o kvm-amd.o
-kvm-objs := kvm_main.o x86.o emulate.o irq.o i8259.o pmu.o \
-	 lapic.o ioapic.o i8254.o coalesced_mmio.o irq_comm.o \
-	 eventfd.o compat-x86.o async_pf.o cpuid.o irqchip.o mtrr.o \
-	 hyperv.o mmu/mmu.o mmu/page_track.o debugfs.o
+kvm-objs := async_pf.o binary_stats.o coalesced_mmio.o compat-x86.o cpuid.o debugfs.o dirty_ring.o \
+	 emulate.o eventfd.o hyperv.o i8254.o i8259.o ioapic.o irq_comm.o irq.o irqchip.o \
+	 kvm_main.o kvm_onhyperv.o lapic.o \
+	 mmu/mmu.o mmu/page_track.o mmu/spte.o mmu/tdp_iter.o mmu/tdp_mmu.o \
+	 mtrr.o pmu.o x86.o xen.o
 ifeq ($(CONFIG_KVM_VFIO),y)
 kvm-objs += vfio.o
 endif
-kvm-intel-objs := vmx/vmx.o vmx/evmcs.o vmx/nested.o vmx/pmu_intel.o \
-	vmx/vmcs12.o vmx/vmenter.o ../hyperv.o
-kvm-amd-objs := svm.o pmu_amd.o
+kvm-intel-objs := ../hyperv.o vmx/evmcs.o vmx/nested.o vmx/pmu_intel.o vmx/posted_intr.o \
+	 vmx/sgx.o vmx/vmcs12.o vmx/vmenter.o vmx/vmx.o
+kvm-amd-objs := svm/avic.o svm/nested.o svm/pmu.o svm/sev.o svm/svm_onhyperv.o svm/svm.o svm/vmenter.o
 
 CFLAGS_kvm_main.o = -DKVM_MAIN


### PR DESCRIPTION
This PR extends the support to compile the kvm-kmod with the Linux Kernel 5.15.
I tested the compilation with Linux Kernel `5.15.0-113-generic` and gcc 11.4.0 in a Ubuntu 22.04 LTS Server VM.
I attached the compilation output 
[kvm-compilation-output.txt](https://github.com/user-attachments/files/16119983/kvm-compilation-output.txt).
After the compilation I only tested the loading of the `kvm.ko` and `kvm-intel.ko` as I am working an an Intel machine.

I hope I didn't miss or forgot anything :)